### PR TITLE
Fix: Precisely Remove BOS Token Prefix from Prompts

### DIFF
--- a/oat/actors/base.py
+++ b/oat/actors/base.py
@@ -125,8 +125,8 @@ class ActorBase(abc.ABC):
         if isinstance(prompts[0], str):
             # Inference with text input
             if self.tokenizer.bos_token:
-                # lstrip bos_token because vllm will add it.
-                prompts = [p.lstrip(self.tokenizer.bos_token) for p in prompts]
+                # removeprefix bos_token because vllm will add it.
+                prompts = [p.removeprefix(self.tokenizer.bos_token) for p in prompts]
             outputs = self.llm.generate(
                 prompts, sampling_params=sampling_params, use_tqdm=False
             )

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -72,9 +72,9 @@ sampling_params = SamplingParams(
 )
 
 if tokenizer.bos_token:
-    # lstrip bos_token because vllm will add it.
+    # removeprefix bos_token because vllm will add it.
     print(conversations[0].startswith(tokenizer.bos_token))
-    conversations = [p.lstrip(tokenizer.bos_token) for p in conversations]
+    conversations = [p.removeprefix(tokenizer.bos_token) for p in conversations]
 
 outputs = llm.generate(conversations[:1], sampling_params)
 


### PR DESCRIPTION
This PR replaced `lstrip(self.tokenizer.bos_token)` with `removeprefix(self.tokenizer.bos_token)` when preprocessing prompts before inference, as `lstrip` may unexpectedly remove additional characters in the prompts. 

One minimal code to reproduce the issue that lstrip might cause: 
```python
bos = "<｜begin▁of▁sentence｜>"
prompt = "<｜begin▁of▁sentence｜><｜User｜>What is the result of 2 + 2?..."

print(f"Prompt: '{prompt}'")
print(f"Apply lstrip: \t\t'{prompt.lstrip(bos)}'")
print(f"Apply removeprefix: \t'{prompt.removeprefix(bos)}'")
```

Output: 
```
Prompt: '<｜begin▁of▁sentence｜><｜User｜>What is the result of 2 + 2?...'
Apply lstrip:           'User｜>What is the result of 2 + 2?...'
Apply removeprefix:     '<｜User｜>What is the result of 2 + 2?...'
```