### PR TITLE
fix: resolve logger warnings

### DIFF
--- a/oat/actors/preference.py
+++ b/oat/actors/preference.py
@@ -43,7 +43,7 @@ class PreferenceActor(ActorBase):
         self.learning_rm = False
         if args.exp_method == "no":
             if self.sampling_params.n > 2:
-                logging.warn(
+                logging.warning(
                     f"trying to sample {self.sampling_params.n} responses but "
                     "no selection mechanism is provided"
                 )

--- a/oat/interface.py
+++ b/oat/interface.py
@@ -42,7 +42,7 @@ def get_program(
             actor_gpus = list(range(args.gpus // 2))
             learner_gpus = list(range(args.gpus // 2, args.gpus))
         else:
-            logging.warn(
+            logging.warning(
                 "Number of GPUs not divisible by 2, one GPU will be forced to collocate learner and actor."
             )
             actor_gpus = list(range(args.gpus // 2 + 1))
@@ -53,7 +53,7 @@ def get_program(
     learner_world_size = len(learner_gpus) * args.num_groups
     args.learner_gpus_per_group = len(learner_gpus)
 
-    logging.warn(
+    logging.warning(
         f"=== GPU allocations ===\nActor: {actor_gpus}, Learner: {learner_gpus}"
     )
 

--- a/oat/oracles/gpt.py
+++ b/oat/oracles/gpt.py
@@ -130,7 +130,7 @@ class GPTJudgeOracle(PreferenceOracleBase):
                 completion, numerator_token="0", denominator_tokens=["0", "1"]
             )
             if np.isnan(first_win_prob):
-                logging.warn("Invalid win prob!")
+                logging.warning("Invalid win prob!")
                 with self.mutex:
                     self.invalid_count += 1
                 return np.random.uniform(0, 1)

--- a/oat/utils/data.py
+++ b/oat/utils/data.py
@@ -301,7 +301,7 @@ class PreferenceDataset(Dataset):
             )
             prompt_ids_len = prompt_token["attention_mask"].int().sum().item()
             if prompt_ids_len >= self.prompt_max_length - 2:
-                logging.warn("Masking samples with too long prompts")
+                logging.warning("Masking samples with too long prompts")
                 loss_mask = True
 
             self.prompt_ids_lens.append(prompt_ids_len)

--- a/oat/utils/ipc.py
+++ b/oat/utils/ipc.py
@@ -54,7 +54,7 @@ class PlasmaShmServer:
                     code = shm_process.poll()
 
                 if code is not None:
-                    logging.warn(f"Plasma daemon process error {code}")
+                    logging.warning(f"Plasma daemon process error {code}")
                     break
 
     def run(self):


### PR DESCRIPTION
## Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```