### PR TITLE
fix: truncated importance sampling to handle precision mismatch

### DIFF
--- a/oat/__about__.py
+++ b/oat/__about__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Version."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/oat/actors/base.py
+++ b/oat/actors/base.py
@@ -70,7 +70,9 @@ class ActorBase(abc.ABC):
 
         self.__vllm_version__ = vllm.__version__
 
-        assert version.parse(self.__vllm_version__) >= version.parse("0.8.3"), "Upgrade to vLLM >= 0.8.3"
+        assert version.parse(self.__vllm_version__) >= version.parse(
+            "0.8.3"
+        ), "Upgrade to vLLM >= 0.8.3"
 
         self.vllm_args.update(
             {

--- a/oat/algorithms/ppo.py
+++ b/oat/algorithms/ppo.py
@@ -86,6 +86,12 @@ class PPOArgs(OATArgs):
         default=1.0,
         metadata={"help": "Scaling the environment rewards."},
     )
+    tis_c: Optional[float] = field(
+        default=None,
+        metadata={
+            "help": "Truncated importance sampling for vllm/deepspeed precision mismatch."
+        },
+    )
     cliprange: float = field(
         default=0.2,
         metadata={"help": "Clip range."},
@@ -363,9 +369,9 @@ class PPOLearner(RLLearner):
             .reshape(-1, 1)
         ).float() * args.reward_scale
         prompt_id_lens = trajectory["prompt_ids_lens"]
-        # action_logprobs = [
-        #     torch.tensor(lp).to(device) for lp in trajectory["action_logprobs"]
-        # ]
+        actor_logprobs = [
+            torch.tensor(lp).to(device) for lp in trajectory["action_logprobs"]
+        ]
         loss_masks = torch.tensor(trajectory["loss_masks"]).float().to(device)
         completion_masks = self.get_completion_mask(att_mask, prompt_id_lens)
         response_masks = completion_masks[:, 1:]
@@ -382,9 +388,9 @@ class PPOLearner(RLLearner):
 
         # Forward old models.
         ## 1) (Option 1) Policy log probabilities are directly from actors (vLLM).
-        # logps = torch.zeros_like(response_masks).float()
-        # for i in range(len(logps)):
-        #     logps[i, torch.where(response_masks[i])[0]] = action_logprobs[i]
+        actor_logps = torch.zeros_like(response_masks).float()
+        for i in range(len(actor_logps)):
+            actor_logps[i, torch.where(response_masks[i])[0]] = actor_logprobs[i]
         ## 2) (Option 2) Reevaluate log probabilities using learner model.
         logps = torch.zeros(
             input_ids.shape[0], input_ids.shape[1] - 1, device=input_ids.device
@@ -471,6 +477,7 @@ class PPOLearner(RLLearner):
                 mb_att_mask = att_mask[mini_batch_inds]
                 mb_response_masks = response_masks[mini_batch_inds]
                 mb_logps = logps[mini_batch_inds]
+                mb_actor_logps = actor_logps[mini_batch_inds]
                 mb_loss_masks = loss_masks[mini_batch_inds]
 
                 # Remove unnecessary padding introduced by the large PPO batch.
@@ -498,6 +505,7 @@ class PPOLearner(RLLearner):
                 mb_att_mask = mb_att_mask[:, :mb_last_valid_token_pos]
                 mb_response_masks = mb_response_masks[:, : mb_last_valid_token_pos - 1]
                 mb_logps = mb_logps[:, : mb_last_valid_token_pos - 1]
+                mb_actor_logps = mb_actor_logps[:, : mb_last_valid_token_pos - 1]
 
                 if self.args.critic_type == "ppo":
                     mb_return = returns[mini_batch_inds, : mb_last_valid_token_pos - 1]
@@ -523,6 +531,12 @@ class PPOLearner(RLLearner):
                         ratio, 1.0 - args.cliprange, 1.0 + args.cliprange
                     )
                     pg_loss_max = torch.max(pg_losses, pg_losses2)
+
+                    if self.args.tis_c is not None:
+                        tis = torch.exp(mb_logps - mb_actor_logps).clamp(
+                            max=self.args.tis_c
+                        )
+                        pg_loss_max *= tis
 
                     stats["logprobs_diff_max"].append(
                         torch.amax(logprobs_diff.detach() * mb_response_masks).item()

--- a/oat/algorithms/ppo.py
+++ b/oat/algorithms/ppo.py
@@ -87,7 +87,7 @@ class PPOArgs(OATArgs):
         metadata={"help": "Scaling the environment rewards."},
     )
     tis_c: Optional[float] = field(
-        default=None,
+        default=2.0,
         metadata={
             "help": "Truncated importance sampling for vllm/deepspeed precision mismatch."
         },

--- a/oat/experiment/run_math_rl.py
+++ b/oat/experiment/run_math_rl.py
@@ -75,11 +75,20 @@ def apply_r1_distill_qwen_template(question: str):
     return "<｜begin▁of▁sentence｜><｜User｜>" + question + "<｜Assistant｜><think>\n"
 
 
+def apply_qwen3_general_template(question: str) -> str:
+    return (
+        f"<|im_start|>user\nQuestion: {question}"
+        "\nPlease reason step by step, and put your final answer within \\boxed{}.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+
+
 TEMPLATE_FACTORY = {
     "qwen_math": apply_qwen_math_template,
     "r1": apply_r1_template,
     "no": apply_no_template,
     "r1_distill_qwen": apply_r1_distill_qwen_template,
+    "qwen3": apply_qwen3_general_template,
 }
 
 
@@ -160,8 +169,8 @@ class MATHOracle(RewardOracleBase, PreferenceOracleBase):
 @dataclass
 class ZeroMathArgs(PPOArgs):
     # Template.
-    prompt_template: Literal["qwen_math", "no", "r1", "r1_distill_qwen"] = field(
-        default="qwen_math"
+    prompt_template: Literal["qwen_math", "no", "r1", "r1_distill_qwen", "qwen3"] = (
+        field(default="qwen_math")
     )
     # Evaluation benchmarks used.
     test_split: str = "all"  # Use "aime,math" to only evaluate on selected benchmarks.
@@ -192,7 +201,7 @@ class ZeroMathActor(PPOActor):
             incorrect_reward=args.incorrect_reward,
         )
 
-        if args.prompt_template in ["qwen_math", "no"]:
+        if args.prompt_template in ["qwen_math", "no", "qwen3"]:
             # These two templates are better used for Qwen models, which can themselves stop generation. Hence we unset all external stopping conditions.
             self.sampling_params.stop = None
             self.sampling_params.stop_token_ids = None


### PR DESCRIPTION
training rewards | gradient norm
---|---
<img width="424" height="307" alt="image" src="https://github.com/user-attachments/assets/c1f51db3-29cd-4c50-93ef-f28a53712ade" />| <img width="422" height="319" alt="image" src="https://github.com/user-attachments/assets/39e4f99c-88ad-411f-bdbd-8ba66b29e5a9" />

With truncated **importance sampling (orange)**, the training becomes more stable.

<img width="1606" height="179" alt="image" src="https://github.com/user-attachments/assets/c4b512ec-6bf7-48fe-9aa8-29fe6402617c" />

Reference: https://fengyao.notion.site/off-policy-rl