### PR TITLE
Fix incorrect state indexing in PPOMultiTurnLearner critic training

### DIFF
--- a/oat/algorithms/ppo_multiturn.py
+++ b/oat/algorithms/ppo_multiturn.py
@@ -423,7 +423,7 @@ class PPOMultiTurnLearner(PPOLearner):
                 mb_advantage = advantages[mini_batch_inds]
                 mb_input_ids = input_ids[mini_batch_inds]
                 mb_att_mask = att_mask[mini_batch_inds]
-                state_ids[mini_batch_inds[0]][None]
+                mb_state_ids = state_ids[mini_batch_inds[0]][None]
 
                 mb_response_masks = response_masks[mini_batch_inds]
                 mb_logps = logps[mini_batch_inds]


### PR DESCRIPTION
## PR Description:

### Summary
This PR fixes a bug in ppo_multiturn.py where the critic network was using an incorrect state index during training, leading to potential training instability and suboptimal performance.

### Problem
In the learning_step method of PPOMultiTurnLearner (line 426), the code incorrectly uses a stale loop variable i to index state_ids:
The variable i comes from an outer loop (line 337 or 369) that has already completed execution. This means that during PPO training epochs, all mini-batches would incorrectly use the same state (corresponding to the last value of i), rather than using the state corresponding to the current mini-batch being trained.

### Root Cause
Unlike other trajectory components (input_ids, att_mask, etc.) which are padded tensors, state_ids is a list of tensors created via tree.map_structure (line 305). Each element in this list corresponds to a different training sample and may have different sequence lengths.
The bug causes the critic to compute value predictions for the wrong state, breaking the PPO algorithm's advantage estimation and value function training.

### Solution
Replace the stale index i with the correct index from mini_batch_inds:
Since train_batch_size_per_device is asserted to be 1 (line 185-186), mini_batch_inds contains exactly one element, and mini_batch_inds[0] correctly retrieves the index of the current sample being trained.

### Changes
File: oat/algorithms/ppo_multiturn.py
Line: 426
Change: state_ids[i][None] → state_ids[mini_batch_inds[0]][None]

### Testing
[ ] Verified that the indexing now correctly retrieves the state corresponding to the current mini-batch
[ ] Ensured consistency with other mini-batch variable indexing patterns (e.g., mb_input_ids, mb_att_mask)
[ ] No impact on non-critic training code paths

### Impact
This fix ensures that the critic network trains on the correct state-value pairs, which should improve training stability and performance for multi-turn PPO with critic-based advantage estimation (critic_type="ppo").