### PR TITLE
fix micro batch training issue in DPO training

### DIFF
--- a/oat/learners/base.py
+++ b/oat/learners/base.py
@@ -202,14 +202,6 @@ class LearnerBase(abc.ABC, DistributedLauncher):
         self.update_interval = args.rollout_batch_size // (
             strategy.world_size * args.rollout_batch_size_per_device
         )
-
-        # if offline mode, update_interval is 1
-        from oat.types import DAPAlgo
-        if (self.algo in DAPAlgo):
-            self.update_interval = 1
-        print("self.update_interval",self.update_interval)
-        
-
         assert (
             args.rollout_batch_size
             % (strategy.world_size * args.rollout_batch_size_per_device)

--- a/oat/learners/offline.py
+++ b/oat/learners/offline.py
@@ -51,12 +51,11 @@ class OfflineLearner(LearnerBase):
                 self.prompt_consumed += bs
                 self.query_step += bs
 
-                if self.steps % self.update_interval == 0:
-                    self._pre_learning()
-                    train_info = self.learn(self.steps // self.update_interval)
-                    self._post_learning()
+                self._pre_learning()
+                train_info = self.learn(self.steps)
+                self._post_learning()
 
-                    self.eval_and_log(train_info)
+                self.eval_and_log(train_info)
 
                 progress_bar.update()
                 self.steps += 1


### PR DESCRIPTION

## Issue
When experimenting with offline DPO, I observed unexpected patterns in learning and LR scheduling:

- With the cosine LR scheduler, `min_lr` should be 10% of `learning_rate` by the end of training. However, it stays almost equal to `learning_rate`.  
- With a single GPU, the policy fails to learn.

---

## Fix for LR Scheduling
To address the scheduling issue, I made the following changes:

- Set `bs = train_batch_size // #gpus` instead of using `rollout_batch_size_per_device`.  
  - The latter doesn’t fit well in the offline learning context.  
- Set `update_interval = 1` (removed the conditional check in the offline training file).  
  - Since offline algorithms don’t have an online rollout process, `update_interval` should always be 1.  
  - A higher value causes data from the dataset to be skipped.

After these changes, the LR scheduling now behaves correctly.  
<img width="683" height="494" alt="image" src="https://github.com/user-attachments/assets/710496f6-57ce-4951-a7b3-88883fc258c8" />

---

## Learning Issue with 1 GPU
Even with the LR fix, performance remains poor in the single-GPU case.  
However, switching from **Zero-2** to **Zero-3** resolves the issue when using:

```
--zero-stage 3 \
--no-use_fused_lm_head \
```

| | zero-2 | zero-3 | 
|---|---|---| 
| use_fused_lm_head=True | bad | - | 
| use_fused_lm_head=False | bad| good |
---

I am still running some ablation experiments to debug. Will update once the experiment is done.