### PR TITLE
Fix incorrect double use of timing variable

### DIFF
--- a/oat/algorithms/ppo.py
+++ b/oat/algorithms/ppo.py
@@ -259,6 +259,7 @@ class PPOLearner(RLLearner):
         if self.critic is not None:
             self.critic.train()
         st = time.time()
+        st_total = time.time()
 
         logging.info(
             f"start learn() buffer_len={len(self.pi_buffer)} dl_len={len(dataloader)}"
@@ -290,7 +291,7 @@ class PPOLearner(RLLearner):
         train_info = {
             "learning_round": learning_round,
             "learn_batch_time": np.mean(learn_batch_time),
-            "total_time": time.time() - st,
+            "total_time": time.time() - st_total,
             **tree.map_structure(lambda x: x.cpu().float().mean().item(), infos),
         }
         train_info = {


### PR DESCRIPTION
The train/total_time logging in ppo.py is incorrect. It uses st for total_time, but resets it at the end of the for loop (supposedly because it is used for learn_batch_time). This results in total_time of 0 being logged every time if self.strategy.grad_acc_step == 1. Fixed by using a separate variable to log the total_time.

https://github.com/sail-sg/oat/blob/c1a074c320ff5ca9fe9a4f669bf05208e2f310be/oat/algorithms/ppo.py#L261-L293